### PR TITLE
GAIA function definition issues

### DIFF
--- a/gaia/cfgFunctions.hpp
+++ b/gaia/cfgFunctions.hpp
@@ -41,7 +41,7 @@ class GAIA
 
     class Control
     {
-        file = "gaia\function\control";
+        file = "gaia\functions\control";
 
         class addAttackWaypoint {};
         class addWaypoint {};
@@ -69,7 +69,6 @@ class GAIA
         class issueOrders {};
         class occupy {};
         class removeWaypoints {};
-        class sortGroupsByConflictArea {};
     };
 
     class Orders

--- a/gaia/cfgFunctionsMod.hpp
+++ b/gaia/cfgFunctionsMod.hpp
@@ -41,7 +41,7 @@ class GAIA
 
     class Control
     {
-        file = "\mcc_sandbox_mod\gaia\function\control";
+        file = "\mcc_sandbox_mod\gaia\functions\control";
 
         class addAttackWaypoint {};
         class addWaypoint {};
@@ -69,7 +69,6 @@ class GAIA
         class issueOrders {};
         class occupy {};
         class removeWaypoints {};
-        class sortGroupsByConflictArea {};
     };
 
     class Orders


### PR DESCRIPTION
Fixed typo in filepath of GAIA Control function definitions.
Removed leftover definition of a function that got replaced.
