### PR TITLE
Fix BIS_fnc_addStackedEventHandler call

### DIFF
--- a/mcc/fnc/general/fn_handleAddaction.sqf
+++ b/mcc/fnc/general/fn_handleAddaction.sqf
@@ -38,7 +38,7 @@ _nul = ["MCC_interactionEH", "onEachFrame", {
 							"PuristaMedium"
 						];
 		} foreach _interactiveObjects;
-	}, ""] call BIS_fnc_addStackedEventHandler;
+	}, [""]] call BIS_fnc_addStackedEventHandler;
 
 
 //Find out interaction key name


### PR DESCRIPTION
BIS_fnc_addStackedEventHandler, parameter 4 is expected to be an array type